### PR TITLE
Fixes neli version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 derive_builder = "0.7.1"
 libc = "0.2.66"
-neli = "0.4.3"
+neli = "=0.4.3"
 thiserror = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Neli introduced a breaking change in version `0.4.4`, this pins the neli version to `0.4.3` so that the package will build.
Fixes #11 