### PR TITLE
cargo: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ xplatform = ["hex", "take-until"]
 [dependencies]
 derive_builder = "0.7.1"
 thiserror = "1.0"
-hex = { version = "0.3.1", optional = true }
+hex = { version = "0.4.3", optional = true }
 take-until = { version = " 0.1.0", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -31,8 +31,8 @@ libc = "0.2.66"
 
 [dev-dependencies]
 anyhow = "1.0"
-base64 = "0.10.1"
-colored = "1.7"
+base64 = "0.13.0"
+colored = "2.0.0"
 tempfile = "3.2.0"
-predicates = "1"
-rand = "0.6.5"
+predicates = "2.1.0"
+rand = "0.8.4"


### PR DESCRIPTION
This pull request updates some of the dependencies to their current versions. I did not update neli, and derive_builder as they require code changes.