### PR TITLE
Cargo: update derive_builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default = []
 xplatform = ["hex", "take-until"]
 
 [dependencies]
-derive_builder = "0.7.1"
+derive_builder = "0.10.2"
 thiserror = "1.0"
 hex = { version = "0.4.3", optional = true }
 take-until = { version = " 0.1.0", optional = true }

--- a/src/linux/err/parse_device_error.rs
+++ b/src/linux/err/parse_device_error.rs
@@ -2,6 +2,8 @@ use crate::linux::err::ParseAttributeError;
 use neli::err::{DeError, NlError};
 use thiserror::Error;
 
+use crate::get::{AllowedIpBuilderError, DeviceBuilderError, PeerBuilderError};
+
 #[derive(Error, Debug)]
 pub enum ParseDeviceError {
     #[error(transparent)]
@@ -24,6 +26,15 @@ pub enum ParseDeviceError {
 
     #[error("Encountered unknown allowed ip attribute id {}", id)]
     UnknownAllowedIpAttributeError { id: u16 },
+
+    #[error(transparent)]
+    AllowedIpBuilderError(#[from] AllowedIpBuilderError),
+
+    #[error(transparent)]
+    DeviceBuilderError(#[from] DeviceBuilderError),
+
+    #[error(transparent)]
+    PeerBuilderError(#[from] PeerBuilderError),
 }
 
 impl From<NlError> for ParseDeviceError {

--- a/src/xplatform/parser/parse.rs
+++ b/src/xplatform/parser/parse.rs
@@ -1,6 +1,6 @@
 use super::state::{ParsePeerState, ParseState};
 use crate::get;
-use crate::get::ParseAllowedIpError;
+use crate::get::{DeviceBuilderError, ParseAllowedIpError, PeerBuilderError};
 use crate::xplatform::protocol::{GetKey, ParseKeyError};
 use std::net::AddrParseError;
 use std::num::ParseIntError;
@@ -28,9 +28,9 @@ pub enum ParseGetResponseError {
     MissingValueForKey(GetKey),
 
     #[error("{0}")]
-    InternalBuildGetDeviceError(String),
+    InternalBuildGetDeviceError(DeviceBuilderError),
     #[error("{0}")]
-    InternalBuildGetPeerError(String),
+    InternalBuildGetPeerError(PeerBuilderError),
 
     #[error("Invalid private_key")]
     InvalidPrivateKey,


### PR DESCRIPTION
This updates the derive_builder dependency to it's current version. Note that this is a non backwards compatible change and thus probably needs a major version according to semver. I want to update neli soon as well, but that is more work.