### PR TITLE
Set codecov to informational mode and disable pull request comments

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,5 @@
+comment: false
+
 coverage:
   status:
     project:


### PR DESCRIPTION
> Use Codecov in informational mode. Default is false. If true is specified the resulting status will pass no matter what the coverage is or what other settings are specified. Informational mode is great to use if you want to expose codecov information to other developers in your pull request without necessarily gating PRs on that information.

https://docs.codecov.com/docs/commit-status#informational