### PR TITLE
xplatform: Make parser module public

### DIFF
--- a/src/xplatform/mod.rs
+++ b/src/xplatform/mod.rs
@@ -20,7 +20,7 @@
 
 mod client;
 pub mod error;
-mod parser;
+pub mod parser;
 mod protocol;
 pub mod set;
 

--- a/src/xplatform/parser/mod.rs
+++ b/src/xplatform/parser/mod.rs
@@ -1,5 +1,5 @@
 mod parse;
 mod state;
 
-pub(crate) use parse::parse;
+pub use parse::parse;
 pub use parse::ParseGetResponseError;

--- a/src/xplatform/parser/parse.rs
+++ b/src/xplatform/parser/parse.rs
@@ -78,7 +78,7 @@ impl From<ParseKeyError> for ParseGetResponseError {
     }
 }
 
-pub(crate) fn parse(
+pub fn parse(
     lines: impl Iterator<Item = Result<String, std::io::Error>>,
 ) -> Result<get::Device, ParseGetResponseError> {
     let initial_state = {


### PR DESCRIPTION
Having parsing facilities public is useful for custom clients.

Closes https://github.com/gluxon/wireguard-uapi-rs/issues/22