### PR TITLE
Add key type to replace naked arrays

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,52 @@
+pub use std::convert::TryFrom;
+
+pub const KEY_SIZE: usize = 32;
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Key([u8; KEY_SIZE]);
+
+pub type PresharedKey = Key;
+pub type PrivateKey = Key;
+pub type PublicKey = Key;
+
+#[derive(Debug, thiserror::Error)]
+pub enum KeyParseError {
+    #[error("Invalid key length: {0} (expected {})", KEY_SIZE)]
+    InvalidLength(usize),
+}
+
+impl Key {
+    pub fn zero() -> Self {
+        Key([0u8; KEY_SIZE])
+    }
+}
+
+impl AsRef<[u8]> for Key {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<[u8; KEY_SIZE]> for Key {
+    fn from(value: [u8; KEY_SIZE]) -> Self {
+        Key(value)
+    }
+}
+
+impl TryFrom<&[u8]> for Key {
+    type Error = KeyParseError;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        let len = value.len();
+
+        if len != KEY_SIZE {
+            return Err(KeyParseError::InvalidLength(len));
+        }
+
+        let mut key = Key::zero();
+
+        key.0.copy_from_slice(value);
+
+        Ok(key)
+    }
+}

--- a/src/get.rs
+++ b/src/get.rs
@@ -1,3 +1,4 @@
+use crate::crypto::{PresharedKey, PrivateKey, PublicKey};
 use derive_builder::Builder;
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
@@ -8,9 +9,9 @@ pub struct Device {
     pub ifindex: u32,
     pub ifname: String,
     #[builder(default)]
-    pub private_key: Option<[u8; 32]>,
+    pub private_key: Option<PrivateKey>,
     #[builder(default)]
-    pub public_key: Option<[u8; 32]>,
+    pub public_key: Option<PublicKey>,
     pub listen_port: u16,
     pub fwmark: u32,
     #[builder(default)]
@@ -22,8 +23,8 @@ pub struct Peer {
     // The public_key and allowed_ips fields are public to
     // make peer coalescing easier.
     #[builder(field(public))]
-    pub public_key: [u8; 32],
-    pub preshared_key: [u8; 32],
+    pub public_key: PublicKey,
+    pub preshared_key: PresharedKey,
     #[builder(default)]
     pub endpoint: Option<SocketAddr>,
     pub persistent_keepalive_interval: u16,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod crypto;
 #[cfg(target_os = "linux")]
 pub mod linux;
 #[cfg(target_os = "linux")]

--- a/src/linux/err/parse_device_error.rs
+++ b/src/linux/err/parse_device_error.rs
@@ -1,4 +1,4 @@
-use crate::linux::err::ParseAttributeError;
+use crate::{crypto::KeyParseError, linux::err::ParseAttributeError};
 use neli::err::{DeError, NlError};
 use thiserror::Error;
 
@@ -35,6 +35,9 @@ pub enum ParseDeviceError {
 
     #[error(transparent)]
     PeerBuilderError(#[from] PeerBuilderError),
+
+    #[error(transparent)]
+    InvalidKeyError(#[from] KeyParseError),
 }
 
 impl From<NlError> for ParseDeviceError {

--- a/src/linux/set/device.rs
+++ b/src/linux/set/device.rs
@@ -1,5 +1,4 @@
-use crate::set::Peer;
-use crate::DeviceInterface;
+use crate::{crypto::PrivateKey, set::Peer, DeviceInterface};
 use std::borrow::Cow;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -15,7 +14,7 @@ pub struct Device<'a> {
     // list below.
     pub flags: Vec<WgDeviceF>,
     /// all zeros to remove
-    pub private_key: Option<&'a [u8; 32]>,
+    pub private_key: Option<&'a PrivateKey>,
     /// 0 to choose randomly
     pub listen_port: Option<u16>,
     /// 0 to disable
@@ -51,7 +50,7 @@ impl<'a> Device<'a> {
         self
     }
 
-    pub fn private_key(mut self, private_key: &'a [u8; 32]) -> Self {
+    pub fn private_key(mut self, private_key: &'a PrivateKey) -> Self {
         self.private_key = Some(private_key);
         self
     }

--- a/src/linux/set/peer.rs
+++ b/src/linux/set/peer.rs
@@ -1,4 +1,7 @@
-use crate::set::AllowedIp;
+use crate::{
+    crypto::{PresharedKey, PublicKey},
+    set::AllowedIp,
+};
 use std::net::SocketAddr;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -11,10 +14,10 @@ pub enum WgPeerF {
 
 #[derive(Debug)]
 pub struct Peer<'a> {
-    pub public_key: &'a [u8; 32],
+    pub public_key: &'a PublicKey,
     pub flags: Vec<WgPeerF>,
     /// all zeros to remove
-    pub preshared_key: Option<&'a [u8; 32]>,
+    pub preshared_key: Option<&'a PresharedKey>,
     pub endpoint: Option<&'a SocketAddr>,
     /// 0 to disable
     pub persistent_keepalive_interval: Option<u16>,
@@ -25,7 +28,7 @@ pub struct Peer<'a> {
 }
 
 impl<'a> Peer<'a> {
-    pub fn from_public_key(public_key: &'a [u8; 32]) -> Self {
+    pub fn from_public_key(public_key: &'a PublicKey) -> Self {
         Self {
             public_key,
             flags: vec![],
@@ -42,7 +45,7 @@ impl<'a> Peer<'a> {
         self
     }
 
-    pub fn preshared_key(mut self, preshared_key: &'a [u8; 32]) -> Self {
+    pub fn preshared_key(mut self, preshared_key: &'a PresharedKey) -> Self {
         self.preshared_key = Some(preshared_key);
         self
     }

--- a/src/xplatform/parser/parse.rs
+++ b/src/xplatform/parser/parse.rs
@@ -1,10 +1,13 @@
 use super::state::{ParsePeerState, ParseState};
-use crate::get;
-use crate::get::{DeviceBuilderError, ParseAllowedIpError, PeerBuilderError};
-use crate::xplatform::protocol::{GetKey, ParseKeyError};
-use std::net::AddrParseError;
-use std::num::ParseIntError;
-use std::{str::FromStr, time::Duration};
+use crate::{
+    crypto::Key,
+    get,
+    get::{DeviceBuilderError, ParseAllowedIpError, PeerBuilderError},
+    xplatform::protocol::{GetKey, ParseKeyError},
+};
+use std::{
+    convert::TryFrom, net::AddrParseError, num::ParseIntError, str::FromStr, time::Duration,
+};
 use take_until::TakeUntilExt;
 use thiserror::Error;
 
@@ -32,8 +35,8 @@ pub enum ParseGetResponseError {
     #[error("{0}")]
     InternalBuildGetPeerError(PeerBuilderError),
 
-    #[error("Invalid private_key")]
-    InvalidPrivateKey,
+    #[error("Invalid private_key: {0}")]
+    InvalidPrivateKey(String),
     #[error("Invalid public_key: `{0}`")]
     InvalidPublicKey(String),
     #[error("Invalid preshared_key: `{0}`")]
@@ -146,10 +149,10 @@ fn process_line(
     match state {
         ParseState::Initial(mut device_builder) => match key {
             GetKey::PrivateKey => {
-                let private_key: [u8; 32] = hex::decode(raw_val)
+                let private_key: Key = hex::decode(raw_val)
                     .ok()
-                    .and_then(|buf| parse_device_key(&buf))
-                    .ok_or(ParseErr::InvalidPrivateKey)?;
+                    .and_then(|buf| Key::try_from(&*buf).ok())
+                    .ok_or_else(|| ParseErr::InvalidPrivateKey(raw_val.to_string()))?;
                 device_builder.private_key(Some(private_key));
                 Ok(ParseState::InterfaceLevelKeys(device_builder))
             }
@@ -184,10 +187,10 @@ fn process_line(
                 let mut peer_builder = get::PeerBuilder::default();
                 let public_key = hex::decode(raw_val)
                     .ok()
-                    .and_then(|buf| parse_device_key(&buf))
+                    .and_then(|buf| Key::try_from(&*buf).ok())
                     .ok_or_else(|| ParseErr::InvalidPublicKey(raw_val.to_string()))?;
                 peer_builder.public_key(public_key);
-                peer_builder.preshared_key([0u8; 32]);
+                peer_builder.preshared_key(Key::zero());
                 peer_builder.persistent_keepalive_interval(0);
                 peer_builder.tx_bytes(0);
                 peer_builder.rx_bytes(0);
@@ -239,10 +242,10 @@ fn process_line(
                 state.peer_builder = get::PeerBuilder::default();
                 let public_key = hex::decode(raw_val)
                     .ok()
-                    .and_then(|buf| parse_device_key(&buf))
+                    .and_then(|buf| Key::try_from(&*buf).ok())
                     .ok_or_else(|| ParseErr::InvalidPublicKey(raw_val.to_string()))?;
                 state.peer_builder.public_key(public_key);
-                state.peer_builder.preshared_key([0u8; 32]);
+                state.peer_builder.preshared_key(Key::zero());
                 state.peer_builder.persistent_keepalive_interval(0);
                 state.peer_builder.tx_bytes(0);
                 state.peer_builder.rx_bytes(0);
@@ -254,7 +257,7 @@ fn process_line(
             GetKey::PresharedKey => {
                 let preshared_key = hex::decode(raw_val)
                     .ok()
-                    .and_then(|buf| parse_device_key(&buf))
+                    .and_then(|buf| Key::try_from(&*buf).ok())
                     .ok_or_else(|| ParseErr::InvalidPresharedKey(raw_val.to_string()))?;
                 state.peer_builder.preshared_key(preshared_key);
                 Ok(ParseState::PeerLevelKeys(state))
@@ -315,22 +318,11 @@ fn process_line(
     }
 }
 
-// TODO: Get this from a shared util
-pub fn parse_device_key(buf: &[u8]) -> Option<[u8; 32]> {
-    if buf.len() != 32 {
-        return None;
-    }
-
-    let mut key = [0u8; 32];
-    key.copy_from_slice(buf);
-    Some(key)
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{parse, parse_device_key};
-    use crate::get;
-    use std::time::Duration;
+    use super::parse;
+    use crate::{crypto::Key, get};
+    use std::{convert::TryFrom, time::Duration};
 
     #[test]
     fn parse_basic() -> anyhow::Result<()> {
@@ -352,18 +344,18 @@ mod tests {
         let expected = get::Device {
             ifindex: 0,
             ifname: "".to_string(),
-            private_key: parse_device_key(&base64::decode(
+            private_key: Some(Key::try_from(&*base64::decode(
                 "GKoQwFpTH1xTehhCazdjh/wsvXAa4bm0Jx4yeqrenU8=",
-            )?),
+            )?)?),
             public_key: None,
             listen_port: 56137,
             fwmark: 0,
             peers: vec![get::Peer {
-                public_key: parse_device_key(&base64::decode(
+                public_key: Key::try_from(&*base64::decode(
                     "kT6g4g4owStcX1qFi5OgXmhtw85SThbzFDu7ECNnl1E=",
                 )?)
                 .unwrap(),
-                preshared_key: [0u8; 32],
+                preshared_key: Key::zero(),
                 endpoint: Some("192.168.64.73:51820".parse()?),
                 last_handshake_time: Duration::new(1_590_459_201, 283_546_000),
                 tx_bytes: 824,
@@ -394,9 +386,9 @@ mod tests {
         let expected = get::Device {
             ifindex: 0,
             ifname: "".to_string(),
-            private_key: parse_device_key(&base64::decode(
+            private_key: Some(Key::try_from(&*base64::decode(
                 "GKoQwFpTH1xTehhCazdjh/wsvXAa4bm0Jx4yeqrenU8=",
-            )?),
+            )?)?),
             public_key: None,
             listen_port: 56137,
             fwmark: 0,
@@ -440,19 +432,19 @@ mod tests {
         let expected = get::Device {
             ifindex: 0,
             ifname: "".to_string(),
-            private_key: parse_device_key(&base64::decode(
+            private_key: Some(Key::try_from(&*base64::decode(
                 "6EtabScXwQA6E7QxVwNT26ypFGzxUMX4V1aA/rpSAno=",
-            )?),
+            )?)?),
             public_key: None,
             listen_port: 12912,
             fwmark: 0,
             peers: vec![
                 get::Peer {
-                    public_key: parse_device_key(&base64::decode(
+                    public_key: Key::try_from(&*base64::decode(
                         "uFmW/sycfx/G0lcqdu2hHVm80gvo5UOxXOS9hajnWjM=",
                     )?)
                     .unwrap(),
-                    preshared_key: parse_device_key(&base64::decode(
+                    preshared_key: Key::try_from(&*base64::decode(
                         "GIUVCT6VL18i6GXO8wEucvi18LWYrAMJ1drM47cPz1I=",
                     )?)
                     .unwrap(),
@@ -469,11 +461,11 @@ mod tests {
                     protocol_version: 1,
                 },
                 get::Peer {
-                    public_key: parse_device_key(&base64::decode(
+                    public_key: Key::try_from(&*base64::decode(
                         "WEAuaVuhdyscyTCXVfBDJR6nf9zxD75jmJzrfhkyE3Y=",
                     )?)
                     .unwrap(),
-                    preshared_key: [0u8; 32],
+                    preshared_key: Key::zero(),
                     endpoint: Some("182.122.22.19:3233".parse()?),
                     last_handshake_time: Duration::new(0, 0),
                     tx_bytes: 38333,
@@ -487,11 +479,11 @@ mod tests {
                     protocol_version: 1,
                 },
                 get::Peer {
-                    public_key: parse_device_key(&base64::decode(
+                    public_key: Key::try_from(&*base64::decode(
                         "Zi4U/VlFVvUiYEcDNANRJYkDtk81VTdj8ZQmqypRXFg=",
                     )?)
                     .unwrap(),
-                    preshared_key: [0u8; 32],
+                    preshared_key: Key::zero(),
                     endpoint: Some("5.152.198.39:51820".parse()?),
                     last_handshake_time: Duration::new(0, 0),
                     tx_bytes: 1_212_111,

--- a/tests/macos.rs
+++ b/tests/macos.rs
@@ -8,6 +8,7 @@ mod tests {
     use std::path::PathBuf;
     use std::process::Command;
     use tempfile::NamedTempFile;
+    use wireguard_uapi::crypto::Key;
 
     const MACOS_WG_SOCK_DIR: &str = "/var/run/wireguard";
 
@@ -75,7 +76,7 @@ mod tests {
         let interface = client.get()?;
         assert_eq!(interface.private_key, None);
 
-        let private_key = curve25519_clamp(rand::random());
+        let private_key = Key::from(curve25519_clamp(rand::random()));
         client.set(set::Device {
             private_key: Some(private_key),
             ..Default::default()


### PR DESCRIPTION
This commit replaces the ever so prevalent 32-large array of u8s with a
tuple struct and some aliases for struct fields. Ideally, those aliases
would be strongly-typed, but sharing the conversion logic from u8 slices
becomes painful.