### PR TITLE
get: Make device peer vector a map

### DIFF
--- a/examples/wg.rs
+++ b/examples/wg.rs
@@ -44,7 +44,7 @@ fn print_device(device: &Device) {
         println!("  {}: {}", "listen port".black().bold(), device.listen_port);
     }
 
-    for peer in &device.peers {
+    for peer in device.peers.values() {
         println!();
         print_peer(peer);
     }

--- a/examples/xplatform.rs
+++ b/examples/xplatform.rs
@@ -31,7 +31,7 @@ fn print_device(device: &Device) {
         println!("  {}: {}", "listen port".black().bold(), device.listen_port);
     }
 
-    for peer in &device.peers {
+    for peer in device.peers.values() {
         println!();
         print_peer(peer);
     }

--- a/src/get.rs
+++ b/src/get.rs
@@ -1,4 +1,5 @@
 use derive_builder::Builder;
+use std::collections::BTreeMap;
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 use std::time::Duration;
@@ -13,8 +14,20 @@ pub struct Device {
     pub public_key: Option<[u8; 32]>,
     pub listen_port: u16,
     pub fwmark: u32,
-    #[builder(default)]
-    pub peers: Vec<Peer>,
+    #[builder(default, setter(custom))]
+    pub peers: BTreeMap<[u8; 32], Peer>,
+}
+
+impl DeviceBuilder {
+    pub fn peers(&mut self, value: Vec<Peer>) -> &mut Self {
+        self.peers = Some(
+            value
+                .into_iter()
+                .map(|peer| (peer.public_key, peer))
+                .collect(),
+        );
+        self
+    }
 }
 
 #[derive(Builder, Clone, Debug, PartialEq)]

--- a/src/xplatform/parser/parse.rs
+++ b/src/xplatform/parser/parse.rs
@@ -349,34 +349,36 @@ mod tests {
             allowed_ip=10.24.24.3/32\n\
             errno=0\n\
             \n";
-        let expected = get::Device {
-            ifindex: 0,
-            ifname: "".to_string(),
-            private_key: parse_device_key(&base64::decode(
-                "GKoQwFpTH1xTehhCazdjh/wsvXAa4bm0Jx4yeqrenU8=",
-            )?),
-            public_key: None,
-            listen_port: 56137,
-            fwmark: 0,
-            peers: vec![get::Peer {
-                public_key: parse_device_key(&base64::decode(
-                    "kT6g4g4owStcX1qFi5OgXmhtw85SThbzFDu7ECNnl1E=",
-                )?)
-                .unwrap(),
-                preshared_key: [0u8; 32],
-                endpoint: Some("192.168.64.73:51820".parse()?),
-                last_handshake_time: Duration::new(1_590_459_201, 283_546_000),
-                tx_bytes: 824,
-                rx_bytes: 696,
-                persistent_keepalive_interval: 110,
-                allowed_ips: vec![get::AllowedIp {
-                    family: 2,
-                    ipaddr: "10.24.24.3".parse()?,
-                    cidr_mask: 32,
-                }],
-                protocol_version: 1,
+        let peers = vec![get::Peer {
+            public_key: parse_device_key(&base64::decode(
+                "kT6g4g4owStcX1qFi5OgXmhtw85SThbzFDu7ECNnl1E=",
+            )?)
+            .unwrap(),
+            preshared_key: [0u8; 32],
+            endpoint: Some("192.168.64.73:51820".parse()?),
+            last_handshake_time: Duration::new(1_590_459_201, 283_546_000),
+            tx_bytes: 824,
+            rx_bytes: 696,
+            persistent_keepalive_interval: 110,
+            allowed_ips: vec![get::AllowedIp {
+                family: 2,
+                ipaddr: "10.24.24.3".parse()?,
+                cidr_mask: 32,
             }],
-        };
+            protocol_version: 1,
+        }];
+        let expected = get::DeviceBuilder::default()
+            .ifindex(0)
+            .ifname("".to_string())
+            .private_key(parse_device_key(&base64::decode(
+                "GKoQwFpTH1xTehhCazdjh/wsvXAa4bm0Jx4yeqrenU8=",
+            )?))
+            .public_key(None)
+            .listen_port(56137)
+            .fwmark(0)
+            .peers(peers)
+            .build()
+            .unwrap();
 
         let actual = parse(response.lines().map(String::from).map(Ok))?;
         assert_eq!(actual, expected);
@@ -391,17 +393,17 @@ mod tests {
             listen_port=56137\n\
             errno=0\n\
             \n";
-        let expected = get::Device {
-            ifindex: 0,
-            ifname: "".to_string(),
-            private_key: parse_device_key(&base64::decode(
+        let expected = get::DeviceBuilder::default()
+            .ifindex(0)
+            .ifname("".to_string())
+            .private_key(parse_device_key(&base64::decode(
                 "GKoQwFpTH1xTehhCazdjh/wsvXAa4bm0Jx4yeqrenU8=",
-            )?),
-            public_key: None,
-            listen_port: 56137,
-            fwmark: 0,
-            peers: vec![],
-        };
+            )?))
+            .public_key(None)
+            .listen_port(56137)
+            .fwmark(0)
+            .build()
+            .unwrap();
 
         let actual = parse(response.lines().map(String::from).map(Ok))?;
         assert_eq!(actual, expected);
@@ -436,83 +438,84 @@ mod tests {
             protocol_version=1\n\
             errno=0\n\
             \n";
-
-        let expected = get::Device {
-            ifindex: 0,
-            ifname: "".to_string(),
-            private_key: parse_device_key(&base64::decode(
+        let peers = vec![
+            get::Peer {
+                public_key: parse_device_key(&base64::decode(
+                    "uFmW/sycfx/G0lcqdu2hHVm80gvo5UOxXOS9hajnWjM=",
+                )?)
+                .unwrap(),
+                preshared_key: parse_device_key(&base64::decode(
+                    "GIUVCT6VL18i6GXO8wEucvi18LWYrAMJ1drM47cPz1I=",
+                )?)
+                .unwrap(),
+                endpoint: Some("[abcd:23::33]:51820".parse()?),
+                last_handshake_time: Duration::new(0, 0),
+                tx_bytes: 0,
+                rx_bytes: 0,
+                persistent_keepalive_interval: 0,
+                allowed_ips: vec![get::AllowedIp {
+                    family: 2,
+                    ipaddr: "192.168.4.4".parse()?,
+                    cidr_mask: 32,
+                }],
+                protocol_version: 1,
+            },
+            get::Peer {
+                public_key: parse_device_key(&base64::decode(
+                    "WEAuaVuhdyscyTCXVfBDJR6nf9zxD75jmJzrfhkyE3Y=",
+                )?)
+                .unwrap(),
+                preshared_key: [0u8; 32],
+                endpoint: Some("182.122.22.19:3233".parse()?),
+                last_handshake_time: Duration::new(0, 0),
+                tx_bytes: 38333,
+                rx_bytes: 2224,
+                persistent_keepalive_interval: 111,
+                allowed_ips: vec![get::AllowedIp {
+                    family: 2,
+                    ipaddr: "192.168.4.6".parse()?,
+                    cidr_mask: 32,
+                }],
+                protocol_version: 1,
+            },
+            get::Peer {
+                public_key: parse_device_key(&base64::decode(
+                    "Zi4U/VlFVvUiYEcDNANRJYkDtk81VTdj8ZQmqypRXFg=",
+                )?)
+                .unwrap(),
+                preshared_key: [0u8; 32],
+                endpoint: Some("5.152.198.39:51820".parse()?),
+                last_handshake_time: Duration::new(0, 0),
+                tx_bytes: 1_212_111,
+                rx_bytes: 1_929_999_999,
+                persistent_keepalive_interval: 0,
+                allowed_ips: vec![
+                    get::AllowedIp {
+                        family: 2,
+                        ipaddr: "192.168.4.10".parse()?,
+                        cidr_mask: 32,
+                    },
+                    get::AllowedIp {
+                        family: 2,
+                        ipaddr: "192.168.4.11".parse()?,
+                        cidr_mask: 32,
+                    },
+                ],
+                protocol_version: 1,
+            },
+        ];
+        let expected = get::DeviceBuilder::default()
+            .ifindex(0)
+            .ifname("".to_string())
+            .private_key(parse_device_key(&base64::decode(
                 "6EtabScXwQA6E7QxVwNT26ypFGzxUMX4V1aA/rpSAno=",
-            )?),
-            public_key: None,
-            listen_port: 12912,
-            fwmark: 0,
-            peers: vec![
-                get::Peer {
-                    public_key: parse_device_key(&base64::decode(
-                        "uFmW/sycfx/G0lcqdu2hHVm80gvo5UOxXOS9hajnWjM=",
-                    )?)
-                    .unwrap(),
-                    preshared_key: parse_device_key(&base64::decode(
-                        "GIUVCT6VL18i6GXO8wEucvi18LWYrAMJ1drM47cPz1I=",
-                    )?)
-                    .unwrap(),
-                    endpoint: Some("[abcd:23::33]:51820".parse()?),
-                    last_handshake_time: Duration::new(0, 0),
-                    tx_bytes: 0,
-                    rx_bytes: 0,
-                    persistent_keepalive_interval: 0,
-                    allowed_ips: vec![get::AllowedIp {
-                        family: 2,
-                        ipaddr: "192.168.4.4".parse()?,
-                        cidr_mask: 32,
-                    }],
-                    protocol_version: 1,
-                },
-                get::Peer {
-                    public_key: parse_device_key(&base64::decode(
-                        "WEAuaVuhdyscyTCXVfBDJR6nf9zxD75jmJzrfhkyE3Y=",
-                    )?)
-                    .unwrap(),
-                    preshared_key: [0u8; 32],
-                    endpoint: Some("182.122.22.19:3233".parse()?),
-                    last_handshake_time: Duration::new(0, 0),
-                    tx_bytes: 38333,
-                    rx_bytes: 2224,
-                    persistent_keepalive_interval: 111,
-                    allowed_ips: vec![get::AllowedIp {
-                        family: 2,
-                        ipaddr: "192.168.4.6".parse()?,
-                        cidr_mask: 32,
-                    }],
-                    protocol_version: 1,
-                },
-                get::Peer {
-                    public_key: parse_device_key(&base64::decode(
-                        "Zi4U/VlFVvUiYEcDNANRJYkDtk81VTdj8ZQmqypRXFg=",
-                    )?)
-                    .unwrap(),
-                    preshared_key: [0u8; 32],
-                    endpoint: Some("5.152.198.39:51820".parse()?),
-                    last_handshake_time: Duration::new(0, 0),
-                    tx_bytes: 1_212_111,
-                    rx_bytes: 1_929_999_999,
-                    persistent_keepalive_interval: 0,
-                    allowed_ips: vec![
-                        get::AllowedIp {
-                            family: 2,
-                            ipaddr: "192.168.4.10".parse()?,
-                            cidr_mask: 32,
-                        },
-                        get::AllowedIp {
-                            family: 2,
-                            ipaddr: "192.168.4.11".parse()?,
-                            cidr_mask: 32,
-                        },
-                    ],
-                    protocol_version: 1,
-                },
-            ],
-        };
+            )?))
+            .public_key(None)
+            .listen_port(12912)
+            .fwmark(0)
+            .peers(peers)
+            .build()
+            .unwrap();
 
         let actual = parse(response.lines().map(String::from).map(Ok))?;
         assert_eq!(actual, expected);

--- a/tests/set_and_get.rs
+++ b/tests/set_and_get.rs
@@ -1,7 +1,10 @@
 #[cfg(target_os = "linux")]
 use {
-    std::net::{IpAddr, Ipv6Addr},
-    std::time::Duration,
+    std::{
+        collections::BTreeMap,
+        net::{IpAddr, Ipv6Addr},
+        time::Duration,
+    },
     wireguard_uapi::{get, set, DeviceInterface, RouteSocket, WgSocket},
 };
 
@@ -31,63 +34,64 @@ fn create_set_allowed_ips(allowed_ips: &[get::AllowedIp]) -> Vec<set::AllowedIp>
 #[cfg(target_os = "linux")]
 #[test]
 fn simple() -> anyhow::Result<()> {
-    let mut test_device = get::Device {
-        ifindex: 0,
-        ifname: get_random_ifname(),
-        private_key: Some(parse_device_key(&base64::decode(
+    let peers = vec![
+        get::PeerBuilder::default()
+            .public_key(parse_device_key(&base64::decode(
+                "DNeiCuVE2CuDy9QH3K3/egRK1rdn/oThlPtWNc4FfSw=",
+            )?))
+            .preshared_key([0u8; 32])
+            .endpoint(Some("[::1]:8080".parse()?))
+            .persistent_keepalive_interval(0)
+            .last_handshake_time(Duration::new(0, 0))
+            .rx_bytes(0)
+            .tx_bytes(0)
+            .allowed_ips(vec![
+                get::AllowedIpBuilder::default()
+                    .family(libc::AF_INET as u16)
+                    .ipaddr("10.24.24.1".parse()?)
+                    .cidr_mask(32)
+                    .build()?,
+                get::AllowedIpBuilder::default()
+                    .family(libc::AF_INET as u16)
+                    .ipaddr("10.24.25.0".parse()?)
+                    .cidr_mask(24)
+                    .build()?,
+            ])
+            .protocol_version(1)
+            .build()?,
+        get::PeerBuilder::default()
+            .public_key(parse_device_key(&base64::decode(
+                "6KUaqULa+M6JI+b6DP3p0ZZZWyClN7ioMpYJp0kNFxQ=",
+            )?))
+            .preshared_key(parse_device_key(&base64::decode(
+                "cMeE5GWUzUbvxbnBKco2MwAnW78nsk8vr04+KupVFkQ=",
+            )?))
+            .endpoint(Some("127.0.0.1:12345".parse()?))
+            .persistent_keepalive_interval(60)
+            .last_handshake_time(Duration::new(0, 0))
+            .rx_bytes(0)
+            .tx_bytes(0)
+            .allowed_ips(vec![get::AllowedIpBuilder::default()
+                .family(libc::AF_INET6 as u16)
+                .ipaddr("::1".parse()?)
+                .cidr_mask(128)
+                .build()?])
+            .protocol_version(1)
+            .build()?,
+    ];
+    let mut test_device = get::DeviceBuilder::default()
+        .ifindex(0)
+        .ifname(get_random_ifname())
+        .private_key(Some(parse_device_key(&base64::decode(
             "EHhtoXVXpnXz31cx8nrAxQfvaRqe1vf343GVSyEtqUU=",
-        )?)),
-        public_key: Some(parse_device_key(&base64::decode(
+        )?)))
+        .public_key(Some(parse_device_key(&base64::decode(
             "MhBzmIBrzw8b8iF2FH4ejh/7Vumn6Q/KoR0H5+o7mlY=",
-        )?)),
-        listen_port: 1234,
-        fwmark: 0,
-        peers: vec![
-            get::Peer {
-                public_key: parse_device_key(&base64::decode(
-                    "DNeiCuVE2CuDy9QH3K3/egRK1rdn/oThlPtWNc4FfSw=",
-                )?),
-                preshared_key: [0u8; 32],
-                endpoint: Some("[::1]:8080".parse()?),
-                persistent_keepalive_interval: 0,
-                last_handshake_time: Duration::new(0, 0),
-                rx_bytes: 0,
-                tx_bytes: 0,
-                allowed_ips: vec![
-                    get::AllowedIp {
-                        family: libc::AF_INET as u16,
-                        ipaddr: "10.24.24.1".parse()?,
-                        cidr_mask: 32,
-                    },
-                    get::AllowedIp {
-                        family: libc::AF_INET as u16,
-                        ipaddr: "10.24.25.0".parse()?,
-                        cidr_mask: 24,
-                    },
-                ],
-                protocol_version: 1,
-            },
-            get::Peer {
-                public_key: parse_device_key(&base64::decode(
-                    "6KUaqULa+M6JI+b6DP3p0ZZZWyClN7ioMpYJp0kNFxQ=",
-                )?),
-                preshared_key: parse_device_key(&base64::decode(
-                    "cMeE5GWUzUbvxbnBKco2MwAnW78nsk8vr04+KupVFkQ=",
-                )?),
-                endpoint: Some("127.0.0.1:12345".parse()?),
-                persistent_keepalive_interval: 60,
-                last_handshake_time: Duration::new(0, 0),
-                rx_bytes: 0,
-                tx_bytes: 0,
-                allowed_ips: vec![get::AllowedIp {
-                    family: libc::AF_INET6 as u16,
-                    ipaddr: "::1".parse()?,
-                    cidr_mask: 128,
-                }],
-                protocol_version: 1,
-            },
-        ],
-    };
+        )?)))
+        .listen_port(1234)
+        .fwmark(0)
+        .peers(peers.clone())
+        .build()?;
 
     let response_device = {
         let mut wg = WgSocket::connect()?;
@@ -101,16 +105,14 @@ fn simple() -> anyhow::Result<()> {
             .listen_port(test_device.listen_port)
             .flags(vec![set::WgDeviceF::ReplacePeers])
             .peers(vec![
-                set::Peer::from_public_key(&test_device.peers[0].public_key)
-                    .endpoint(test_device.peers[0].endpoint.as_ref().unwrap())
-                    .allowed_ips(create_set_allowed_ips(&test_device.peers[0].allowed_ips)),
-                set::Peer::from_public_key(&test_device.peers[1].public_key)
-                    .preshared_key(&test_device.peers[1].preshared_key)
-                    .endpoint(test_device.peers[1].endpoint.as_ref().unwrap())
-                    .persistent_keepalive_interval(
-                        test_device.peers[1].persistent_keepalive_interval,
-                    )
-                    .allowed_ips(create_set_allowed_ips(&test_device.peers[1].allowed_ips)),
+                set::Peer::from_public_key(&peers[0].public_key)
+                    .endpoint(peers[0].endpoint.as_ref().unwrap())
+                    .allowed_ips(create_set_allowed_ips(&peers[0].allowed_ips)),
+                set::Peer::from_public_key(&peers[1].public_key)
+                    .preshared_key(&peers[1].preshared_key)
+                    .endpoint(peers[1].endpoint.as_ref().unwrap())
+                    .persistent_keepalive_interval(peers[1].persistent_keepalive_interval)
+                    .allowed_ips(create_set_allowed_ips(&peers[1].allowed_ips)),
             ]);
 
         wg.set_device(set_device_args)?;
@@ -157,28 +159,18 @@ fn set_ifname_has_proper_padding() -> anyhow::Result<()> {
 #[cfg(target_os = "linux")]
 #[test]
 fn large_peer() -> anyhow::Result<()> {
-    let mut test_device = get::Device {
-        ifindex: 6,
-        ifname: get_random_ifname(),
-        private_key: Some(parse_device_key(&base64::decode(
-            "yAnz5TF+lXXJte14tji3zlMNq+hd2rYUIgJBgB3fBmk=",
-        )?)),
-        public_key: Some(parse_device_key(&base64::decode(
-            "HIgo9xNzJMWLKASShiTqIybxZ0U3wGLiUeJ1PKf8ykw=",
-        )?)),
-        listen_port: 51820,
-        fwmark: 0,
-        peers: vec![get::Peer {
-            public_key: parse_device_key(&base64::decode(
-                "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=",
-            )?),
-            preshared_key: [0u8; 32],
-            endpoint: Some("192.95.5.67:1234".parse()?),
-            persistent_keepalive_interval: 0,
-            last_handshake_time: Duration::new(0, 0),
-            rx_bytes: 0,
-            tx_bytes: 0,
-            allowed_ips: (1..=2u16.pow(12))
+    let peers = vec![get::PeerBuilder::default()
+        .public_key(parse_device_key(&base64::decode(
+            "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=",
+        )?))
+        .preshared_key([0u8; 32])
+        .endpoint(Some("192.95.5.67:1234".parse()?))
+        .persistent_keepalive_interval(0)
+        .last_handshake_time(Duration::new(0, 0))
+        .rx_bytes(0)
+        .tx_bytes(0)
+        .allowed_ips(
+            (1..=2u16.pow(12))
                 .step_by(1)
                 .map(|i| get::AllowedIp {
                     family: libc::AF_INET6 as u16,
@@ -186,9 +178,22 @@ fn large_peer() -> anyhow::Result<()> {
                     cidr_mask: 128,
                 })
                 .collect(),
-            protocol_version: 1,
-        }],
-    };
+        )
+        .protocol_version(1)
+        .build()?];
+    let mut test_device = get::DeviceBuilder::default()
+        .ifindex(6)
+        .ifname(get_random_ifname())
+        .private_key(Some(parse_device_key(&base64::decode(
+            "yAnz5TF+lXXJte14tji3zlMNq+hd2rYUIgJBgB3fBmk=",
+        )?)))
+        .public_key(Some(parse_device_key(&base64::decode(
+            "HIgo9xNzJMWLKASShiTqIybxZ0U3wGLiUeJ1PKf8ykw=",
+        )?)))
+        .listen_port(51820)
+        .fwmark(0)
+        .peers(peers.clone())
+        .build()?;
 
     let response_device = {
         let mut wg = WgSocket::connect()?;
@@ -197,11 +202,11 @@ fn large_peer() -> anyhow::Result<()> {
         route.add_device(&test_device.ifname)?;
 
         let set_device_args = {
-            let peer = set::Peer::from_public_key(&test_device.peers[0].public_key)
-                .preshared_key(&test_device.peers[0].preshared_key)
-                .endpoint(test_device.peers[0].endpoint.as_ref().unwrap())
-                .persistent_keepalive_interval(test_device.peers[0].persistent_keepalive_interval)
-                .allowed_ips(create_set_allowed_ips(&test_device.peers[0].allowed_ips));
+            let peer = set::Peer::from_public_key(&peers[0].public_key)
+                .preshared_key(&peers[0].preshared_key)
+                .endpoint(peers[0].endpoint.as_ref().unwrap())
+                .persistent_keepalive_interval(peers[0].persistent_keepalive_interval)
+                .allowed_ips(create_set_allowed_ips(&peers[0].allowed_ips));
 
             set::Device::from_ifname(&test_device.ifname)
                 .private_key(test_device.private_key.as_ref().unwrap())
@@ -240,7 +245,7 @@ fn peer_update_only() -> anyhow::Result<()> {
         )?)),
         listen_port: 51820,
         fwmark: 0,
-        peers: vec![],
+        peers: BTreeMap::new(),
     };
 
     let response_device = {
@@ -266,7 +271,7 @@ fn peer_update_only() -> anyhow::Result<()> {
         response_device
     };
 
-    assert_eq!(response_device.peers, vec![]);
+    assert!(response_device.peers.is_empty());
 
     Ok(())
 }


### PR DESCRIPTION
Currently, peers in a device are stored as a vector, which requires
iterating to find a peer by its public key, so this commit changes it to
be a hash map.