### PR TITLE
update neli to 0.6.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ hex = { version = "0.4.3", optional = true }
 take-until = { version = " 0.1.0", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-neli = "=0.5.3"
+neli = "=0.6.3"
 libc = "0.2.66"
 
 [dev-dependencies]

--- a/src/linux/attr.rs
+++ b/src/linux/attr.rs
@@ -1,5 +1,5 @@
 use neli::consts::genl::NlAttrType;
-use neli::impl_var;
+use neli::neli_enum;
 use std::fmt;
 
 // As of neli 0.4.3, the NLA_F_NESTED flag needs to be added to newly created
@@ -29,31 +29,31 @@ macro_rules! impl_bit_ops_for_nla {
     };
 }
 
-impl_var!(
-    pub NlaNested, u16,
-    Unspec => 0,
+#[neli_enum(serialized_type = "u16")]
+pub enum NlaNested {
+    Unspec = 0,
     // neli requires 1 non-zero argument even though WireGuard
     // does not use it.
-    Unused => 1
-);
+    Unused = 1,
+}
 
 impl NlAttrType for NlaNested {}
 
 impl_bit_ops_for_nla!(NlaNested);
 
 // https://github.com/WireGuard/WireGuard/blob/62b335b56cc99312ccedfa571500fbef3756a623/src/uapi/wireguard.h#L147
-impl_var!(
-    pub WgDeviceAttribute, u16,
-    Unspec => 0,
-    Ifindex => 1,
-    Ifname => 2,
-    PrivateKey => 3,
-    PublicKey => 4,
-    Flags => 5,
-    ListenPort => 6,
-    Fwmark => 7,
-    Peers => 8
-);
+#[neli_enum(serialized_type = "u16")]
+pub enum WgDeviceAttribute {
+    Unspec = 0,
+    Ifindex = 1,
+    Ifname = 2,
+    PrivateKey = 3,
+    PublicKey = 4,
+    Flags = 5,
+    ListenPort = 6,
+    Fwmark = 7,
+    Peers = 8,
+}
 
 impl NlAttrType for WgDeviceAttribute {}
 
@@ -66,20 +66,20 @@ impl fmt::Display for WgDeviceAttribute {
 impl_bit_ops_for_nla!(WgDeviceAttribute);
 
 // https://github.com/WireGuard/WireGuard/blob/62b335b56cc99312ccedfa571500fbef3756a623/src/uapi/wireguard.h#L165
-impl_var!(
-    pub WgPeerAttribute, u16,
-    Unspec => 0,
-    PublicKey => 1,
-    PresharedKey => 2,
-    Flags => 3,
-    Endpoint => 4,
-    PersistentKeepaliveInterval => 5,
-    LastHandshakeTime => 6,
-    RxBytes => 7,
-    TxBytes => 8,
-    AllowedIps => 9,
-    ProtocolVersion => 10
-);
+#[neli_enum(serialized_type = "u16")]
+pub enum WgPeerAttribute {
+    Unspec = 0,
+    PublicKey = 1,
+    PresharedKey = 2,
+    Flags = 3,
+    Endpoint = 4,
+    PersistentKeepaliveInterval = 5,
+    LastHandshakeTime = 6,
+    RxBytes = 7,
+    TxBytes = 8,
+    AllowedIps = 9,
+    ProtocolVersion = 10,
+}
 
 impl NlAttrType for WgPeerAttribute {}
 
@@ -92,11 +92,12 @@ impl fmt::Display for WgPeerAttribute {
 impl_bit_ops_for_nla!(WgPeerAttribute);
 
 // https://github.com/WireGuard/WireGuard/blob/62b335b56cc99312ccedfa571500fbef3756a623/src/uapi/wireguard.h#L181
-impl_var!(
-    pub WgAllowedIpAttribute, u16,
-    Unspec => 0,
-    Family => 1,
-    IpAddr => 2,
-    CidrMask => 3
-);
+#[neli_enum(serialized_type = "u16")]
+pub enum WgAllowedIpAttribute {
+    Unspec = 0,
+    Family = 1,
+    IpAddr = 2,
+    CidrMask = 3,
+}
+
 impl NlAttrType for WgAllowedIpAttribute {}

--- a/src/linux/cmd.rs
+++ b/src/linux/cmd.rs
@@ -1,10 +1,11 @@
-use neli::{consts::genl::Cmd, impl_var};
+use neli::consts::genl::Cmd;
+use neli::neli_enum;
 
 // https://github.com/WireGuard/WireGuard/blob/62b335b56cc99312ccedfa571500fbef3756a623/src/uapi/wireguard.h#L137
-impl_var!(
-    pub WgCmd, u8,
-    GetDevice => 0,
-    SetDevice => 1
-);
+#[neli_enum(serialized_type = "u8")]
+pub enum WgCmd {
+    GetDevice = 0,
+    SetDevice = 1,
+}
 
 impl Cmd for WgCmd {}

--- a/src/linux/err/connect_error.rs
+++ b/src/linux/err/connect_error.rs
@@ -1,4 +1,9 @@
+use neli::consts::{
+    genl::{CtrlAttr, CtrlCmd},
+    nl::GenlId,
+};
 use neli::err::NlError;
+use neli::genl::Genlmsghdr;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -7,7 +12,7 @@ pub enum ConnectError {
     NlError(NlError),
 
     #[error("Unable to connect to the WireGuard DKMS. Is WireGuard installed?")]
-    ResolveFamilyError(#[source] NlError),
+    ResolveFamilyError(#[source] NlError<GenlId, Genlmsghdr<CtrlCmd, CtrlAttr>>),
 }
 
 impl From<NlError> for ConnectError {

--- a/src/linux/interface.rs
+++ b/src/linux/interface.rs
@@ -26,14 +26,12 @@ impl<'a> TryFrom<&DeviceInterface<'a>> for Nlattr<WgDeviceAttribute, Buffer> {
     fn try_from(interface: &DeviceInterface) -> Result<Self, Self::Error> {
         let attr = match interface {
             &DeviceInterface::Index(ifindex) => Nlattr::new(
-                None,
                 false,
                 NLA_NETWORK_ORDER,
                 WgDeviceAttribute::Ifindex,
                 ifindex,
             )?,
             DeviceInterface::Name(ifname) => Nlattr::new(
-                None,
                 false,
                 NLA_NETWORK_ORDER,
                 WgDeviceAttribute::Ifname,

--- a/src/linux/set/allowed_ip.rs
+++ b/src/linux/set/allowed_ip.rs
@@ -27,14 +27,13 @@ impl<'a> TryFrom<&AllowedIp<'a>> for Nlattr<NlaNested, Buffer> {
 
     fn try_from(allowed_ip: &AllowedIp) -> Result<Self, Self::Error> {
         let mut nested =
-            Nlattr::new::<Vec<u8>>(None, false, false, NlaNested::Unspec | NLA_F_NESTED, vec![])?;
+            Nlattr::new::<Vec<u8>>(false, false, NlaNested::Unspec | NLA_F_NESTED, vec![])?;
 
         let family = match allowed_ip.ipaddr {
             IpAddr::V4(_) => libc::AF_INET as u16,
             IpAddr::V6(_) => libc::AF_INET6 as u16,
         };
         nested.add_nested_attribute(&Nlattr::new(
-            None,
             false,
             NLA_NETWORK_ORDER,
             WgAllowedIpAttribute::Family,
@@ -46,7 +45,6 @@ impl<'a> TryFrom<&AllowedIp<'a>> for Nlattr<NlaNested, Buffer> {
             IpAddr::V6(addr) => addr.octets().to_vec(),
         };
         nested.add_nested_attribute(&Nlattr::new(
-            None,
             false,
             NLA_NETWORK_ORDER,
             WgAllowedIpAttribute::IpAddr,
@@ -58,7 +56,6 @@ impl<'a> TryFrom<&AllowedIp<'a>> for Nlattr<NlaNested, Buffer> {
             IpAddr::V6(_) => 128,
         });
         nested.add_nested_attribute(&Nlattr::new(
-            None,
             false,
             NLA_NETWORK_ORDER,
             WgAllowedIpAttribute::CidrMask,

--- a/src/linux/socket/route_socket.rs
+++ b/src/linux/socket/route_socket.rs
@@ -3,12 +3,7 @@ use super::{link_message, WireGuardDeviceLinkOperation};
 use crate::err::{ConnectError, LinkDeviceError, ListDevicesError};
 use list_device_names_utils::PotentialWireGuardDeviceName;
 use neli::{
-    consts::{
-        genl::{CtrlAttr, CtrlCmd},
-        nl::{NlTypeWrapper, Nlmsg},
-        socket::NlFamily,
-    },
-    genl::Genlmsghdr,
+    consts::{nl::Nlmsg, socket::NlFamily},
     rtnl::Ifinfomsg,
     socket::NlSocketHandle,
 };
@@ -20,30 +15,26 @@ pub struct RouteSocket {
 
 impl RouteSocket {
     pub fn connect() -> Result<Self, ConnectError> {
-        let sock = NlSocketHandle::new(NlFamily::Route)?;
-
         // Autoselect a PID
         let pid = None;
         let groups = &[];
-        sock.bind(pid, groups)?;
+        let sock = NlSocketHandle::connect(NlFamily::Route, pid, groups)?;
 
         Ok(Self { sock })
     }
 
     pub fn add_device(&mut self, ifname: &str) -> Result<(), LinkDeviceError> {
         let operation = WireGuardDeviceLinkOperation::Add;
-
         self.sock.send(link_message(ifname, operation)?)?;
-        self.sock.recv::<Nlmsg, Genlmsghdr<CtrlCmd, CtrlAttr>>()?;
+        self.sock.recv()?;
 
         Ok(())
     }
 
     pub fn del_device(&mut self, ifname: &str) -> Result<(), LinkDeviceError> {
         let operation = WireGuardDeviceLinkOperation::Delete;
-
         self.sock.send(link_message(ifname, operation)?)?;
-        self.sock.recv::<Nlmsg, Genlmsghdr<CtrlCmd, CtrlAttr>>()?;
+        self.sock.recv()?;
 
         Ok(())
     }
@@ -54,14 +45,14 @@ impl RouteSocket {
         self.sock
             .send(list_device_names_utils::get_list_device_names_msg())?;
 
-        let mut iter = self.sock.iter::<Ifinfomsg>(false);
+        let mut iter = self.sock.iter::<Nlmsg, Ifinfomsg>(false);
 
         let mut result_names = vec![];
 
         while let Some(Ok(response)) = iter.next() {
             match response.nl_type {
-                NlTypeWrapper::Nlmsg(Nlmsg::Error) => return Err(ListDevicesError::Unknown),
-                NlTypeWrapper::Nlmsg(Nlmsg::Done) => break,
+                Nlmsg::Error => return Err(ListDevicesError::Unknown),
+                Nlmsg::Done => break,
                 _ => (),
             }
 


### PR DESCRIPTION
    API changes:

    - impl_var!() removed in 0.6.0.
    - Trait Nl removed in 0.6.0.
    - Stream{Read,Write}Buffer have been obsoleted.
    - There's an enum IflaInfo for IFLA_INFO_* defines.
    - NlPayload type for Genlmsghdr payload.
    - Track NlSocketHandle API changes (::connect() over ::open()/::bind()).
    - Simplified header deserialization via FromBytesWithInput trait.
    - The asize() member function disappeared.
