### PR TITLE
Loosen dependency on neli to ^0.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,9 +242,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "neli"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1805440578ced23f85145d00825c0a831e43c587132a90e100552172543ae30"
+checksum = "93062a0dce6da2517ea35f301dfc88184ce18d3601ec786a727a87bf535deca9"
 dependencies = [
  "byteorder",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ hex = { version = "0.4.3", optional = true }
 take-until = { version = " 0.1.0", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-neli = "=0.6.3"
+neli = "0.6.3"
 libc = "0.2.66"
 
 [dev-dependencies]

--- a/tests/enodev.rs
+++ b/tests/enodev.rs
@@ -27,9 +27,10 @@ fn missing_device_returns_sensible_error() -> anyhow::Result<()> {
     // TODO: Ensure this library returns more sensible errors. Update the "No
     // ack received" string below to "No device found by interface name or
     // public key".
-    // As of neli 0.5.3 the library returns ENODEV instead of “No ack
-    // received”.
-    assert!(existing_err_message.starts_with("Error response received from netlink: Unknown error"));
+    // As of neli 0.6.5 the library returns "No such device".
+    assert!(
+        existing_err_message.starts_with("Error response received from netlink: No such device")
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Fixes https://github.com/gluxon/wireguard-uapi-rs/issues/32