### PR TITLE
Add a new `Key` type to represent any key material

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wireguard-uapi"
-version = "3.0.1"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -608,6 +608,7 @@ dependencies = [
  "take-until",
  "tempfile",
  "thiserror",
+ "zeroize",
 ]
 
 [[package]]
@@ -633,6 +634,26 @@ name = "zerocopy-derive"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wireguard-uapi"
-version = "3.0.1"
+version = "4.0.0"
 edition = "2018"
 authors = ["Brandon Cheng <brandon.cheng@protonmail.com>"]
 license = "MIT"
@@ -27,6 +27,7 @@ derive_builder = "0.10.2"
 thiserror = "1.0"
 hex = { version = "0.4.3", optional = true }
 take-until = { version = " 0.1.0", optional = true }
+zeroize = { version = "1.8.1", features = ["derive"], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 neli = "0.6.3"

--- a/examples/wg.rs
+++ b/examples/wg.rs
@@ -55,7 +55,7 @@ fn print_peer(peer: &Peer) {
     println!(
         "{}: {}",
         "peer".yellow(),
-        base64::encode(peer.public_key).yellow()
+        base64::encode(&peer.public_key).yellow()
     );
     if let Some(endpoint) = peer.endpoint {
         println!("  {}: {}", "endpoint".black().bold(), endpoint);

--- a/examples/xplatform.rs
+++ b/examples/xplatform.rs
@@ -40,7 +40,7 @@ fn print_peer(peer: &Peer) {
     println!(
         "{}: {}",
         "peer".yellow(),
-        base64::encode(peer.public_key).yellow()
+        base64::encode(&peer.public_key).yellow()
     );
     if let Some(endpoint) = peer.endpoint {
         println!("  {}: {}", "endpoint".black().bold(), endpoint);

--- a/src/get.rs
+++ b/src/get.rs
@@ -3,14 +3,16 @@ use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 use std::time::Duration;
 
+use crate::key::Key;
+
 #[derive(Builder, Debug, PartialEq, Eq)]
 pub struct Device {
     pub ifindex: u32,
     pub ifname: String,
     #[builder(default)]
-    pub private_key: Option<[u8; 32]>,
+    pub private_key: Option<Key>,
     #[builder(default)]
-    pub public_key: Option<[u8; 32]>,
+    pub public_key: Option<Key>,
     pub listen_port: u16,
     pub fwmark: u32,
     #[builder(default)]
@@ -22,8 +24,8 @@ pub struct Peer {
     // The public_key and allowed_ips fields are public to
     // make peer coalescing easier.
     #[builder(field(public))]
-    pub public_key: [u8; 32],
-    pub preshared_key: [u8; 32],
+    pub public_key: Key,
+    pub preshared_key: Key,
     #[builder(default)]
     pub endpoint: Option<SocketAddr>,
     pub persistent_keepalive_interval: u16,

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,0 +1,35 @@
+use std::ops::{Deref, DerefMut};
+
+/// Key material, public, private or preshared.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
+pub struct Key([u8; 32]);
+
+impl Deref for Key {
+    type Target = [u8; 32];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Key {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl AsRef<[u8]> for Key {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<[u8; 32]> for Key {
+    fn from(#[allow(unused_mut)] mut value: [u8; 32]) -> Self {
+        let ret = Self(value);
+        #[cfg(feature = "zeroize")]
+        zeroize::Zeroize::zeroize(&mut value);
+        ret
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod linux;
 pub use linux::{err, set, DeviceInterface, RouteSocket, WgSocket};
 
 pub mod get;
+pub mod key;
 
 #[cfg(feature = "xplatform")]
 pub mod xplatform;

--- a/src/xplatform/set.rs
+++ b/src/xplatform/set.rs
@@ -1,3 +1,4 @@
+use crate::key::Key;
 use crate::xplatform::protocol::SetKey;
 use std::fmt::Display;
 use std::net::IpAddr;
@@ -11,7 +12,7 @@ pub struct Device {
     /// the interface. The value may be an all zero string in the case of a set
     /// operation, in which case it indicates that the private key should be
     /// removed.
-    pub private_key: Option<[u8; 32]>,
+    pub private_key: Option<Key>,
 
     /// The value for this is a decimal-string integer corresponding to the
     /// listening port of the interface.
@@ -32,7 +33,7 @@ pub struct Device {
 
 impl Display for Device {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(private_key) = self.private_key {
+        if let Some(private_key) = &self.private_key {
             let private_key = hex::encode(private_key);
             writeln!(f, "{}={}", SetKey::PrivateKey, private_key)?;
         }
@@ -80,7 +81,7 @@ pub struct Peer {
     /// the previously added peer entry. The value may be an all zero string in
     /// the case of a set operation, in which case it indicates that the
     /// preshared-key should be removed.
-    pub preshared_key: Option<[u8; 32]>,
+    pub preshared_key: Option<Key>,
 
     /// The value for this key is either IP:port for IPv4 or \[IP\]:port for
     /// IPv6, indicating the endpoint of the previously added peer entry.
@@ -128,7 +129,7 @@ impl Peer {
         self
     }
 
-    pub fn preshared_key(mut self, preshared_key: [u8; 32]) -> Self {
+    pub fn preshared_key(mut self, preshared_key: Key) -> Self {
         self.preshared_key = Some(preshared_key);
         self
     }
@@ -166,7 +167,7 @@ impl Display for Peer {
             writeln!(f, "{}={}", SetKey::UpdateOnly, update_only)?;
         }
 
-        if let Some(preshared_key) = self.preshared_key {
+        if let Some(preshared_key) = &self.preshared_key {
             let preshared_key = hex::encode(preshared_key);
             writeln!(f, "{}={}", SetKey::PresharedKey, preshared_key)?;
         }
@@ -241,11 +242,14 @@ mod tests {
             remove=true\n";
 
         let set_request = Device {
-            private_key: Some([
-                0xe8, 0x4b, 0x5a, 0x6d, 0x27, 0x17, 0xc1, 0x00, 0x3a, 0x13, 0xb4, 0x31, 0x57, 0x03,
-                0x53, 0xdb, 0xac, 0xa9, 0x14, 0x6c, 0xf1, 0x50, 0xc5, 0xf8, 0x57, 0x56, 0x80, 0xfe,
-                0xba, 0x52, 0x02, 0x7a,
-            ]),
+            private_key: Some(
+                [
+                    0xe8, 0x4b, 0x5a, 0x6d, 0x27, 0x17, 0xc1, 0x00, 0x3a, 0x13, 0xb4, 0x31, 0x57,
+                    0x03, 0x53, 0xdb, 0xac, 0xa9, 0x14, 0x6c, 0xf1, 0x50, 0xc5, 0xf8, 0x57, 0x56,
+                    0x80, 0xfe, 0xba, 0x52, 0x02, 0x7a,
+                ]
+                .into(),
+            ),
             listen_port: Some(12912),
             fwmark: Some(0),
             replace_peers: Some(true),
@@ -255,11 +259,14 @@ mod tests {
                     0xed, 0xa1, 0x1d, 0x59, 0xbc, 0xd2, 0x0b, 0xe8, 0xe5, 0x43, 0xb1, 0x5c, 0xe4,
                     0xbd, 0x85, 0xa8, 0xe7, 0x5a, 0x33,
                 ])
-                .preshared_key([
-                    0x18, 0x85, 0x15, 0x09, 0x3e, 0x95, 0x2f, 0x5f, 0x22, 0xe8, 0x65, 0xce, 0xf3,
-                    0x01, 0x2e, 0x72, 0xf8, 0xb5, 0xf0, 0xb5, 0x98, 0xac, 0x03, 0x09, 0xd5, 0xda,
-                    0xcc, 0xe3, 0xb7, 0x0f, 0xcf, 0x52,
-                ])
+                .preshared_key(
+                    [
+                        0x18, 0x85, 0x15, 0x09, 0x3e, 0x95, 0x2f, 0x5f, 0x22, 0xe8, 0x65, 0xce,
+                        0xf3, 0x01, 0x2e, 0x72, 0xf8, 0xb5, 0xf0, 0xb5, 0x98, 0xac, 0x03, 0x09,
+                        0xd5, 0xda, 0xcc, 0xe3, 0xb7, 0x0f, 0xcf, 0x52,
+                    ]
+                    .into(),
+                )
                 .replace_allowed_ips(true)
                 .allowed_ips(vec![AllowedIp {
                     ipaddr: "192.168.4.4".parse().unwrap(),
@@ -322,11 +329,14 @@ mod tests {
         .join("\n");
 
         let set_request = Device {
-            private_key: Some([
-                0xe8, 0x4b, 0x5a, 0x6d, 0x27, 0x17, 0xc1, 0x00, 0x3a, 0x13, 0xb4, 0x31, 0x57, 0x03,
-                0x53, 0xdb, 0xac, 0xa9, 0x14, 0x6c, 0xf1, 0x50, 0xc5, 0xf8, 0x57, 0x56, 0x80, 0xfe,
-                0xba, 0x52, 0x02, 0x7a,
-            ]),
+            private_key: Some(
+                [
+                    0xe8, 0x4b, 0x5a, 0x6d, 0x27, 0x17, 0xc1, 0x00, 0x3a, 0x13, 0xb4, 0x31, 0x57,
+                    0x03, 0x53, 0xdb, 0xac, 0xa9, 0x14, 0x6c, 0xf1, 0x50, 0xc5, 0xf8, 0x57, 0x56,
+                    0x80, 0xfe, 0xba, 0x52, 0x02, 0x7a,
+                ]
+                .into(),
+            ),
             peers: vec![Peer::from_public_key([
                 0xb8, 0x59, 0x96, 0xfe, 0xcc, 0x9c, 0x7f, 0x1f, 0xc6, 0xd2, 0x57, 0x2a, 0x76, 0xed,
                 0xa1, 0x1d, 0x59, 0xbc, 0xd2, 0x0b, 0xe8, 0xe5, 0x43, 0xb1, 0x5c, 0xe4, 0xbd, 0x85,

--- a/tests/macos.rs
+++ b/tests/macos.rs
@@ -8,6 +8,7 @@ mod tests {
     use std::path::PathBuf;
     use std::process::Command;
     use tempfile::NamedTempFile;
+    use wireguard_uapi::key::Key;
 
     const MACOS_WG_SOCK_DIR: &str = "/var/run/wireguard";
 
@@ -21,7 +22,7 @@ mod tests {
         // /var/run/wireguard folder.
         // https://github.com/WireGuard/wireguard-go#macos
         let wireguard_go_status = Command::new("wireguard-go")
-            .args(&["utun"])
+            .args(["utun"])
             .env("WG_TUN_NAME_FILE", ifname_output_file.path().as_os_str())
             .status()?;
         if !wireguard_go_status.success() {
@@ -75,9 +76,9 @@ mod tests {
         let interface = client.get()?;
         assert_eq!(interface.private_key, None);
 
-        let private_key = curve25519_clamp(rand::random());
+        let private_key: Key = curve25519_clamp(rand::random()).into();
         client.set(set::Device {
-            private_key: Some(private_key),
+            private_key: Some(private_key.clone()),
             ..Default::default()
         })?;
         let interface = client.get()?;

--- a/tests/set_and_get.rs
+++ b/tests/set_and_get.rs
@@ -1,4 +1,7 @@
 #[cfg(target_os = "linux")]
+use wireguard_uapi::key::Key;
+
+#[cfg(target_os = "linux")]
 use {
     std::net::{IpAddr, Ipv6Addr},
     std::time::Duration,
@@ -11,8 +14,8 @@ fn get_random_ifname() -> String {
 }
 
 #[cfg(target_os = "linux")]
-fn parse_device_key(buf: &[u8]) -> [u8; 32] {
-    let mut key = [0u8; 32];
+fn parse_device_key(buf: &[u8]) -> Key {
+    let mut key = Key::default();
     key.copy_from_slice(buf);
     key
 }
@@ -47,7 +50,7 @@ fn simple() -> anyhow::Result<()> {
                 public_key: parse_device_key(&base64::decode(
                     "DNeiCuVE2CuDy9QH3K3/egRK1rdn/oThlPtWNc4FfSw=",
                 )?),
-                preshared_key: [0u8; 32],
+                preshared_key: Key::default(),
                 endpoint: Some("[::1]:8080".parse()?),
                 persistent_keepalive_interval: 0,
                 last_handshake_time: Duration::new(0, 0),
@@ -172,7 +175,7 @@ fn large_peer() -> anyhow::Result<()> {
             public_key: parse_device_key(&base64::decode(
                 "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=",
             )?),
-            preshared_key: [0u8; 32],
+            preshared_key: Key::default(),
             endpoint: Some("192.95.5.67:1234".parse()?),
             persistent_keepalive_interval: 0,
             last_handshake_time: Duration::new(0, 0),


### PR DESCRIPTION
The new type (optionally) implements `Zeroize` and `ZeroizeOnDrop`. This change makes it possible to remove the key material from memory.